### PR TITLE
Blacklist faulty sites

### DIFF
--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracFaultySites.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracFaultySites.java
@@ -1,0 +1,84 @@
+package fr.insalyon.creatis.gasw.plugin.executor.dirac.execution;
+
+import org.apache.log4j.Logger;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DiracFaultySites {
+
+    private static final Logger logger = Logger.getLogger("fr.insalyon.creatis.gasw");
+    private Map<String, DiracFaultySite> faultySites;
+
+    public DiracFaultySites() {
+        this.faultySites = new HashMap<>();
+    }
+
+    public void reportErrorOnSite (String siteName) {
+        logger.info("[DiracFaultySites] Report error on site " + siteName);
+        if (this.faultySites.containsKey(siteName)) {
+            this.faultySites.get(siteName).addError();
+        } else {
+            this.faultySites.put(siteName, new DiracFaultySite(siteName));
+        }
+    }
+
+    public void reportSuccessOnSite(String siteName) {
+        logger.info("[DiracFaultySites] Report success on site " + siteName +". Removing it from the list.");
+        if (this.faultySites.containsKey(siteName)) {
+            this.faultySites.remove(siteName);
+        }
+    }
+
+    public List<String> getBannedSitesList (){
+        List<String> list = new ArrayList<>();
+        for (DiracFaultySite faultySite : this.faultySites.values()) {
+            if (faultySite.toBeBanned()) {
+                list.add(faultySite.getSiteName());
+            }
+        }
+        return list;
+    }
+
+    class DiracFaultySite {
+        private String siteName;
+        private LocalDateTime timestamp;
+        private int nbErrors;
+
+        public DiracFaultySite(String siteName) {
+            this.timestamp = LocalDateTime.now();
+            this.siteName = siteName;
+            this.nbErrors = 1;
+        }
+
+        public String getSiteName() {
+            return this.siteName;
+        }
+
+        public boolean toBeBanned() {
+            LocalDateTime currentTime = LocalDateTime.now();
+            Duration duration = Duration.between(currentTime, this.timestamp);
+            long diff = Math.abs(duration.toMinutes());
+            //exponential back-off
+            if (diff < Math.pow(2, (this.nbErrors - 1))) {
+                logger.info("[DiracFaultySite] site " + siteName + " is banned since time diff in min since last failure is "+
+                        diff + ", and the number of errors is " +this.nbErrors);
+                return true;
+            } else {
+                logger.info("[DiracFaultySite] site " + siteName + " is NOT to be banned since time diff in min since last failure is "+
+                        diff + ", and the number of errors is " +this.nbErrors);
+                return false;
+            }
+        }
+
+        public void addError() {
+            this.timestamp = LocalDateTime.now();
+            this.nbErrors = this.nbErrors + 1;
+        }
+    }
+
+
+}

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracFaultySites.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracFaultySites.java
@@ -64,12 +64,12 @@ public class DiracFaultySites {
             long diff = Math.abs(duration.toMinutes());
             //exponential back-off
             if (diff < Math.pow(2, (this.nbErrors - 1))) {
-                logger.info("[DiracFaultySite] site " + siteName + " is banned since time diff in min since last failure is "+
-                        diff + ", and the number of errors is " +this.nbErrors);
+                logger.info("[DiracFaultySite] site " + siteName + " is banned since last failure was "+
+                        diff + " min ago, and the number of errors is " +this.nbErrors);
                 return true;
             } else {
-                logger.info("[DiracFaultySite] site " + siteName + " is NOT to be banned since time diff in min since last failure is "+
-                        diff + ", and the number of errors is " +this.nbErrors);
+                logger.info("[DiracFaultySite] site " + siteName + " is NOT to be banned since last failure was "+
+                        diff + " min ago, and the number of errors is " +this.nbErrors);
                 return false;
             }
         }

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracMonitor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracMonitor.java
@@ -81,7 +81,6 @@ public class DiracMonitor extends GaswMonitor {
         Process process = null;
         try {
             DiracJdlGenerator generator = DiracJdlGenerator.getInstance();
-            DiracFaultySites diracFaultySites = generator.getDiracFaultySites();
 
             while (!stop) {
 
@@ -173,11 +172,11 @@ public class DiracMonitor extends GaswMonitor {
                                 switch (status) {
                                     case Done:
                                         job.setStatus(GaswStatus.COMPLETED);
-                                        diracFaultySites.reportSuccessOnSite(job.getDiracSite());
+                                        generator.getDiracFaultySites((job.getCommand())).reportSuccessOnSite(job.getDiracSite());
                                         break;
                                     case Failed:
                                         job.setStatus(GaswStatus.ERROR);
-                                        diracFaultySites.reportErrorOnSite(job.getDiracSite());
+                                        generator.getDiracFaultySites((job.getCommand())).reportErrorOnSite(job.getDiracSite());
                                         break;
                                     case Killed:
                                         job.setStatus(GaswStatus.CANCELLED);

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracMonitor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracMonitor.java
@@ -79,11 +79,11 @@ public class DiracMonitor extends GaswMonitor {
     @Override
     public void run() {
         Process process = null;
-        try {
-            DiracJdlGenerator generator = DiracJdlGenerator.getInstance();
+        DiracJdlGenerator generator;
 
-            while (!stop) {
-
+        while (!stop) {
+            try {
+                generator = DiracJdlGenerator.getInstance();
                 verifySignaledJobs();
 
                 List<Job> jobsList = jobDAO.getActiveJobs();
@@ -119,7 +119,7 @@ public class DiracMonitor extends GaswMonitor {
                             DiracStatus status = DiracStatus.valueOf(res[1].replace("Status=", "").replace(";", ""));
                             String diracSite = siteRes[2].replace("Site=", "").replace(";", "").trim();
 
-                            if ( (!diracSite.equalsIgnoreCase("ANY")) && (job.getDiracSite()==null) ) {
+                            if ((!diracSite.equalsIgnoreCase("ANY")) && (job.getDiracSite() == null)) {
                                 logger.info("Dirac Monitor: setting dirac Site to ***" + diracSite + "*** for job id " + jobIdReturnedByDirac);
                                 job.setDiracSite(diracSite);
                                 jobDAO.update(job);
@@ -137,7 +137,7 @@ public class DiracMonitor extends GaswMonitor {
                                         + job.getStatus() + " ] is a replicate of a finished job");
                                 if (job.getStatus() != GaswStatus.CANCELLED_REPLICA) {
                                     logger.info("Dirac Monitor: job \"" + job.getId() +
-                                            "\" [ status : "+ job.getStatus() +
+                                            "\" [ status : " + job.getStatus() +
                                             " ] is a replicate of a finished job" +
                                             " but has not been properly killed");
                                     job.setStatus(GaswStatus.CANCELLED_REPLICA);
@@ -222,15 +222,15 @@ public class DiracMonitor extends GaswMonitor {
                     checkMissingDiracJob(command.subList(1, command.size()), jobIdsReturnedByDirac);
                 }
                 Thread.sleep(GaswConfiguration.getInstance().getDefaultSleeptime());
-            }
-        } catch (IOException | GaswException | DAOException ex) {
+
+            } catch (IOException | GaswException | DAOException ex) {
                 logger.error("[DIRAC] error monitoring DIRAC jobs", ex);
             } catch (InterruptedException ex) {
                 logger.error("[DIRAC] jobs monitoring thread interrupted" + ex);
             } finally {
                 closeProcess(process);
             }
-
+        }
     }
 
     private void checkMissingDiracJob(List<String> sentJobIds, List<String> returnedJobIds) {

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracMonitor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracMonitor.java
@@ -119,7 +119,7 @@ public class DiracMonitor extends GaswMonitor {
                             DiracStatus status = DiracStatus.valueOf(res[1].replace("Status=", "").replace(";", ""));
                             String diracSite = siteRes[2].replace("Site=", "").replace(";", "").trim();
 
-                            if ((!diracSite.equalsIgnoreCase("ANY")) && (job.getDiracSite() == null)) {
+                            if ( (!diracSite.equalsIgnoreCase("ANY")) && (job.getDiracSite() == null) ) {
                                 logger.info("Dirac Monitor: setting dirac Site to ***" + diracSite + "*** for job id " + jobIdReturnedByDirac);
                                 job.setDiracSite(diracSite);
                                 jobDAO.update(job);

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracOutputParser.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracOutputParser.java
@@ -43,6 +43,8 @@ import java.io.File;
 import java.io.IOException;
 import org.apache.log4j.Logger;
 
+import static fr.insalyon.creatis.gasw.plugin.executor.dirac.execution.DiracJdlGenerator.*;
+
 /**
  *
  * @author Rafael Ferreira da Silva, Tram Truong Huu
@@ -198,6 +200,8 @@ public class DiracOutputParser extends GaswOutputParser {
 
     @Override
     protected void resubmit() throws GaswException {
+        DiracJdlGenerator generator = DiracJdlGenerator.getInstance();
+        generator.updateBannedSitesInJdl(job.getFileName() + ".jdl");
         try {
             DiracDAOFactory.getInstance().getJobPoolDAO().add(
                     new JobPool(job.getFileName(), job.getCommand(), job.getParameters()));
@@ -207,4 +211,5 @@ public class DiracOutputParser extends GaswOutputParser {
         }
 
     }
+
 }


### PR DESCRIPTION
Sites on which a command fails are blacklisted for a timespan that increases with the number of errors. 
Site blacklisting is done w.r.t. the command, i.e. the site is blacklisted for a command but not for the other ones.  
A blacklisted site is removed from the blacklist when a job completes the command successefully on that site.