### PR TITLE
bug dirac not present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,40 +59,13 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- config necessary to include the maven version
-             into the MANIFEST file of the default jar-->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
             </plugin>
             <plugin>
               <artifactId>maven-surefire-plugin</artifactId>
-              <version>2.21.0</version>
-              <dependencies>
-                <dependency>
-                  <groupId>org.junit.platform</groupId>
-                  <artifactId>junit-platform-surefire-provider</artifactId>
-                  <version>1.2.0</version>
-                </dependency>
-                <dependency>
-                  <groupId>org.junit.jupiter</groupId>
-                  <artifactId>junit-jupiter-engine</artifactId>
-                  <version>5.2.0</version>
-                </dependency>
-              </dependencies>
+              <version>3.5.2</version>
             </plugin>
         </plugins>
     </build>
@@ -106,10 +79,17 @@
         </dependency>
 
         <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-engine</artifactId>
-          <version>5.2.0</version>
-          <scope>test</scope>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.13.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     

--- a/src/test/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/DiracExecutorTest.java
+++ b/src/test/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/DiracExecutorTest.java
@@ -1,0 +1,41 @@
+package fr.insalyon.creatis.gasw.plugin.executor.dirac;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import fr.insalyon.creatis.gasw.GaswException;
+import fr.insalyon.creatis.gasw.GaswUtil;
+
+/**
+ * For these tests we assume that dirac is NOT available in the environnement!
+ */
+public class DiracExecutorTest {
+
+    @Test
+    public void testDiracNotAvailable() throws GaswException {
+        DiracExecutor executor = new DiracExecutor();
+
+        assertThrows(GaswException.class, () -> executor.checkDiracAvailable());
+    }
+
+    @Test
+    public void testDiracAvailable() throws GaswException {
+        DiracExecutor executor = new DiracExecutor();
+        Logger logger = Logger.getLogger("fr.insalyon.creatis.gasw");
+
+        Process mockProcess = mock(Process.class);
+        when(mockProcess.exitValue()).thenReturn(0);
+
+        MockedStatic<GaswUtil> util = Mockito.mockStatic(GaswUtil.class);
+        util.when(() -> GaswUtil.getProcess(logger, "dirac-version")).thenReturn(mockProcess);
+
+        assertDoesNotThrow(() -> executor.checkDiracAvailable());
+    }
+}


### PR DESCRIPTION
This ensure that dirac is present in the environnement by testing `dirac-version` command. This was developed to avoid infinite loop created by the plugin.