### PR TITLE
dirac fix kill

### DIFF
--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/DiracConfiguration.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/DiracConfiguration.java
@@ -63,7 +63,6 @@ public class DiracConfiguration {
     private List<Object> siteNamesToIgnore;
 
     public static DiracConfiguration getInstance() throws GaswException {
-
         if (instance == null) {
             instance = new DiracConfiguration();
         }

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/DiracExecutor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/DiracExecutor.java
@@ -44,10 +44,6 @@ import java.util.List;
 import net.xeoh.plugins.base.annotations.PluginImplementation;
 import org.apache.log4j.Logger;
 
-/**
- *
- * @author Rafael Ferreira da Silva
- */
 @PluginImplementation
 public class DiracExecutor implements ExecutorPlugin {
 
@@ -82,14 +78,19 @@ public class DiracExecutor implements ExecutorPlugin {
 
     @Override
     public String submit() throws GaswException {
-
         return diracSubmit.submit();
     }
 
     @Override
     public void terminate() throws GaswException {
+        DiracMonitor monitor = DiracMonitor.getInstance();
 
-        DiracSubmit.terminate();
-        DiracMonitor.getInstance().terminate();
+        try {
+            diracSubmit.terminate();
+            monitor.interrupt();
+            monitor.join();
+        } catch (InterruptedException e) {
+            logger.warn("Hard-kill occured!");
+        }
     }
 }

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracMonitor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracMonitor.java
@@ -329,7 +329,7 @@ public class DiracMonitor extends GaswMonitor {
             } else {
                 for (Job job: jobs) {
                     logger.info("Deleted DIRAC Job ID '" + job.getId()  + "' (current status : " + job.getStatus() + ")");
-                    // update status to set a final one : CANCELLED or DELETED, with an optional _REPLICA suffix
+                    // update status to set a final one : DELETED, with an optional _REPLICA suffix
                     // at the beginning, status should be KILL or KILL_REPLICA, but we keep support if it was already a final one
                     switch (job.getStatus()) {
                         case KILL_REPLICA:
@@ -338,16 +338,6 @@ public class DiracMonitor extends GaswMonitor {
                         case KILL:
                             job.setStatus(GaswStatus.DELETED);
                             break;
-                        case CANCELLED:
-                            logger.warn("A canceled job should not have a kill request");
-                            job.setStatus(GaswStatus.DELETED);
-                            break;
-                        case CANCELLED_REPLICA:
-                            logger.warn("A canceled job should not have a kill request");
-                            job.setStatus(GaswStatus.DELETED_REPLICA);
-                            break;
-                        case DELETED:
-                        case DELETED_REPLICA:
                         default:
                             job.setStatus(GaswStatus.DELETED);
                             logger.error("Wrong job status to have a kill request." + job.getStatus());

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracMonitor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracMonitor.java
@@ -219,6 +219,7 @@ public class DiracMonitor extends GaswMonitor {
             } catch (InterruptedException ex) {
                 logger.error("[DIRAC] jobs monitoring thread interrupted" + ex);
                 terminate();
+                break;
             } finally {
                 closeProcess(process);
             }
@@ -348,12 +349,14 @@ public class DiracMonitor extends GaswMonitor {
                         case DELETED:
                         case DELETED_REPLICA:
                         default:
-                            logger.error("Wrong job status to have a kill request " + job.getStatus());
+                            job.setStatus(GaswStatus.DELETED);
+                            logger.error("Wrong job status to have a kill request." + job.getStatus());
+                            logger.warn("Job set to default status DELETED.");
                             break;
                     }
                     updateStatus(job);
     
-                    if (GaswStatus.CANCELLED.equals(job.getStatus()) || GaswStatus.DELETED.equals(job.getStatus())) {
+                    if (GaswStatus.DELETED.equals(job.getStatus())) {
                         // invocation is over, inform moteur and listeners
                         new DiracOutputParser(job.getId()).start();
                     } else {

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracMonitor.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracMonitor.java
@@ -340,7 +340,7 @@ public class DiracMonitor extends GaswMonitor {
                             break;
                         default:
                             job.setStatus(GaswStatus.DELETED);
-                            logger.error("Wrong job status to have a kill request." + job.getStatus());
+                            logger.warn("Wrong job status to have a kill request." + job.getStatus());
                             logger.warn("Job set to default status DELETED.");
                             break;
                     }

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracSubmit.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracSubmit.java
@@ -52,19 +52,11 @@ import fr.insalyon.creatis.gasw.execution.GaswSubmit;
 import fr.insalyon.creatis.gasw.plugin.executor.dirac.bean.JobPool;
 import fr.insalyon.creatis.gasw.plugin.executor.dirac.dao.DiracDAOFactory;
 
-/**
- *
- * @author Rafael Ferreira da Silva
- */
 public class DiracSubmit extends GaswSubmit {
 
     private static final Logger logger = Logger.getLogger("fr.insalyon.creatis.gasw");
-    private volatile static SubmitPool submitPool;
+    private SubmitPool submitPool;
 
-    /**
-     *
-     * @param gaswInput
-     */
     public DiracSubmit(GaswInput gaswInput,
             DiracMinorStatusServiceGenerator minorStatusServiceGenerator) throws GaswException {
 
@@ -100,11 +92,6 @@ public class DiracSubmit extends GaswSubmit {
         }
     }
 
-    /**
-     *
-     * @param scriptName
-     * @return
-     */
     private String generateJdl(String scriptName) throws GaswException {
 
         DiracJdlGenerator generator = DiracJdlGenerator.getInstance();
@@ -116,15 +103,10 @@ public class DiracSubmit extends GaswSubmit {
      */
     private class SubmitPool extends Thread {
 
-        private boolean stop = false;
-
-        public SubmitPool() {
-        }
-
         @Override
         public void run() {
 
-            while (!stop) {
+            while (true) {
                 Process process = null;
                 try {
 
@@ -191,10 +173,6 @@ public class DiracSubmit extends GaswSubmit {
                 }
             }
         }
-
-        public void terminate() {
-            this.stop = true;
-        }
     }
 
     private void signalInvocationJob(JobPool jobPool) {
@@ -215,19 +193,13 @@ public class DiracSubmit extends GaswSubmit {
         }
     }
 
-    public static void terminate() {
-
+    public void terminate() throws InterruptedException {
         if (submitPool != null) {
-            submitPool.terminate();
+            submitPool.interrupt();
+            submitPool.join();
         }
     }
 
-    /**
-     * Closes a process.
-     *
-     * @param process
-     * @throws IOException
-     */
     private void closeProcess(Process process) {
         if (process != null) {
             try {

--- a/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracSubmit.java
+++ b/src/main/java/fr/insalyon/creatis/gasw/plugin/executor/dirac/execution/DiracSubmit.java
@@ -168,6 +168,7 @@ public class DiracSubmit extends GaswSubmit {
                     logger.error("[DIRAC] error submitting DIRAC jobs", ex);
                 } catch (InterruptedException ex) {
                     logger.error("[DIRAC] jobs submitting thread interrupted" + ex);
+                    break;
                 } finally {
                     closeProcess(process);
                 }


### PR DESCRIPTION
- every job killed is now set to the **status** `deleted` or `deleted_replica`, the status `cancelled` won't be used anymore in this case.
- simplification using only the `dirac-wms-job-delete` command which handles both `running` and `queue` job states.
- remove old references to _minorstatus_